### PR TITLE
Add prometheus support

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -15,7 +15,7 @@ rbd-map-image:
       description: "Name of ceph pool for test. Defaults to config option pool-name"
     image-size:
       type: integer
-      default: 1024
+      default: 20480
       description: "Size of the RBD image."
 rados-bench:
   description: "Run the rados bench performance test"
@@ -93,7 +93,7 @@ fio:
       description: "If using the default rbd device, name of ceph pool for test. Defaults to config option pool-name"
     image-size:
       type: integer
-      default: 1024
+      default: 20480
       description: "Size of the RBD image."
     block-size:
       type: string

--- a/actions.yaml
+++ b/actions.yaml
@@ -111,3 +111,7 @@ fio:
       type: integer
       default: 8
       description: "Number of GET operations to permform"
+    runtime:
+      type: integer
+      default: 60
+      description: "Limit the duration of the test"

--- a/config.yaml
+++ b/config.yaml
@@ -31,3 +31,8 @@ options:
     default: ceph-benchmarking
     description: |
       Ceph pool name for tests to use.
+  push-gateway:
+    type: string
+    default:
+    description: |
+      IP address of Prometheus Push Gateway

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 Jinja2<=2.10.1
 PyYAML<=5.2
 netaddr<=0.7.19
+prometheus_client
 git+https://github.com/juju/charm-helpers.git@87fc7ee5#egg=charmhelpers
 git+https://github.com/canonical/operator.git@0.8.0#egg=ops
 git+https://opendev.org/openstack/charm-ops-interface-ceph-client@cc10f29d4#egg=interface_ceph_client

--- a/src/bench_tools.py
+++ b/src/bench_tools.py
@@ -69,7 +69,7 @@ class BenchTools():
         return _output.decode("UTF-8")
 
     def fio(self, fio_conf):
-        _cmd = ["fio", fio_conf]
+        _cmd = ["fio", "--output-format=json", fio_conf]
         _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)
         return _output.decode("UTF-8")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import hashlib
 import socket
 import logging
 import os
@@ -108,7 +109,14 @@ class CephBenchmarkingCharmBase(ops_openstack.core.OSBaseCharm):
     SWIFT_USER = "{}:swift".format(CLIENT_NAME)
 
     RBD_MOUNT = Path("/mnt/ceph-block-device")
-    RBD_IMAGE = "rbdimage01"
+
+    @property
+    def RBD_IMAGE(self):
+        hash = hashlib.sha1(
+            self.model.unit.name.encode("UTF-8")
+        ).hexdigest()
+        return hash[:10]
+
     RBD_DEV = Path("/dev/rbd")
 
     REQUIRED_RELATIONS = ["ceph-client"]

--- a/templates/rbd.fio
+++ b/templates/rbd.fio
@@ -7,6 +7,10 @@ rbdname={{ action_params.rbd_image }}
 rw={{ action_params.operation }}
 bs={{ action_params.block_size }}
 numjobs={{ action_params.num_jobs }}
+group_reporting=1
+{% if action_params.runtime %}
+runtime={{ action_params.runtime }}
+{% endif %}
 [rbd_iodepth32]
 iodepth={{ action_params.iodepth }}
 {% endif %}


### PR DESCRIPTION
Report metrics for FIO tests directly to a prometheus push gateway
when the fio action is run.

Push gateway is configured using a configuration option.

Results are reported at the end of each test and don't report
performance over the time the test takes to complete.

Add runtime option to fio action to allow fixed duration tests to
be executed.