### PR TITLE
Add juju storage support

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -83,11 +83,6 @@ fio:
       type: string
       description: |
         If unset, use the charm default rbd device in the ceph pool. If set run fio, against the set disk. Space delimited list of devices.
-    ioengine:
-      type: string
-      default: rbd
-      description: |
-        IO Engine for fio
     pool-name:
       type: string
       description: "If using the default rbd device, name of ceph pool for test. Defaults to config option pool-name"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,3 +23,8 @@ requires:
 peers:
   peers:
     interface: ceph-benchmarking-peer
+storage:
+  test-devices:
+    type: block
+    multiple:
+      range: 0-

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,9 +138,7 @@ class CephBenchmarkingCharmBase(ops_openstack.core.OSBaseCharm):
     TLS_CA_CERT_PATH = Path(
         "/usr/local/share/ca-certificates/vault_ca_cert.crt")
     # We have no services to restart so using configs_for_rendering.
-    configs_for_rendering = [
-        str(CEPH_CONF),
-        str(BENCHMARK_KEYRING)]
+    configs_for_rendering = []
     release = "default"
     bindings = ["cluster", "peers", "public"]
     action_output_key = "test-results"
@@ -307,15 +305,15 @@ class CephBenchmarkingCharmBase(ops_openstack.core.OSBaseCharm):
         :returns: This method is called for its side effects
         :rtype: None
         """
-        if not self.ceph_client.pools_available:
-            print("Defering setup pools")
-            logging.info("Defering setup")
-            event.defer()
-            return
-
-        self.CEPH_CONFIG_PATH.mkdir(
-            exist_ok=True,
-            mode=0o750)
+        ceph_storage = self.ceph_client.pools_available
+        if ceph_storage:
+            self.configs_for_rendering += [
+                str(self.CEPH_CONF),
+                str(self.BENCHMARK_KEYRING)
+            ]
+            self.CEPH_CONFIG_PATH.mkdir(
+                exist_ok=True,
+                mode=0o750)
 
         def _render_configs():
             for config_file in self.configs_for_rendering:
@@ -671,6 +669,14 @@ class CephBenchmarkingCharmBase(ops_openstack.core.OSBaseCharm):
                   results.
         :rtype: None
         """
+        test_devices = self.model.storages.get('test-devices')
+        # If storage binding provided then override disk-devices
+        # unless the application is related to ceph.
+        if not self.ceph_client.pools_available and test_devices:
+            event.params["disk-devices"] = (
+                " ".join([str(d.location) for d in test_devices])
+            )
+
         # If not disk specified use RBD mount
         if not event.params.get("disk-devices"):
             # Prepare the rbd image

--- a/src/charm.py
+++ b/src/charm.py
@@ -122,7 +122,11 @@ class CephBenchmarkingCharmBase(ops_openstack.core.OSBaseCharm):
 
     RBD_DEV = Path("/dev/rbd")
 
-    REQUIRED_RELATIONS = ["ceph-client"]
+    @property
+    def REQUIRED_RELATIONS(self):
+        if not self.model.storages.get('test-devices'):
+            return ["ceph-client"]
+        return []
 
     CEPH_CONFIG_PATH = Path("/etc/ceph")
     RBD_FIO_CONF = CEPH_CONFIG_PATH / "rbd.fio"

--- a/src/charm.py
+++ b/src/charm.py
@@ -692,9 +692,11 @@ class CephBenchmarkingCharmBase(ops_openstack.core.OSBaseCharm):
             event.params["client"] = self.CLIENT_NAME
             event.params["rbd_image"] = self.RBD_IMAGE
             event.params["pool_name"] = self.get_pool_name(event)
+            event.params["ioengine"] = 'rbd'
             _fio_conf = str(self.RBD_FIO_CONF)
         else:
             event.params["disk_devices"] = event.params["disk-devices"].split()
+            event.params["ioengine"] = 'libaio'
             _fio_conf = str(self.DISK_FIO_CONF)
 
         # Add action_parms to adapters

--- a/templates/disk.fio
+++ b/templates/disk.fio
@@ -6,6 +6,10 @@ direct=1
 rw={{ action_params.operation }}
 bs={{ action_params.block_size }}
 numjobs={{ action_params.num_jobs }}
+group_reporting=1
+{% if action_params.runtime %}
+runtime={{ action_params.runtime }}
+{% endif %}
 {% for dev in action_params.disk_devices %}
 [job {{loop.index}}]
 filename={{dev}}


### PR DESCRIPTION
Support use of FIO action with Juju provided block storage
devices.

Note that this is a little adjunct to the primary use case
for this charm and I did ponder having a separate FIO
charm.

The juju provided block storage devices are only used
when the charm is not related to Ceph.
