### PR TITLE
Set URL for swift-bench

### DIFF
--- a/templates/swift-bench.conf
+++ b/templates/swift-bench.conf
@@ -1,6 +1,7 @@
 {% if action_params %}
 [bench]
 auth = {{ action_params.protocol }}://{{ action_params.swift_address }}/auth/v1.0
+url = {{ action_params.protocol }}://{{ action_params.swift_address }}/swift/v1
 concurrency = {{ action_params.concurrency }}
 object_size = {{ action_params.object_size }}
 num_objects = {{ action_params.num_objects }}


### PR DESCRIPTION
When using TLS it is necessary to set the URL for the rados gw as well
as the auth url.