### PR TITLE
Support installing snap from charm tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lib/*
 !lib/README.txt
 build
 ceph-benchmarking.charm
+src/snap/*.snap

--- a/src/snap/README.txt
+++ b/src/snap/README.txt
@@ -1,0 +1,1 @@
+Copies of snap can be placed here


### PR DESCRIPTION
To work around juju bug which causes slow resource downloads,
support including the swift bench snap in the charm.

*1 https://bugs.launchpad.net/juju/+bug/1905703