### PR TITLE
Rework prometheus integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,11 +31,6 @@ options:
     default: ceph-benchmarking
     description: |
       Ceph pool name for tests to use.
-  push-gateway:
-    type: string
-    default:
-    description: |
-      IP address of Prometheus Push Gateway
   ssl_ca:
     type: string
     default:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,6 +26,9 @@ requires:
     interface: ceph-client
   certificates:
     interface: tls-certificates
+provides:
+  prometheus-target:
+    interface: http
 peers:
   peers:
     interface: ceph-benchmarking-peer

--- a/templates/disk.fio
+++ b/templates/disk.fio
@@ -7,9 +7,7 @@ rw={{ action_params.operation }}
 bs={{ action_params.block_size }}
 numjobs={{ action_params.num_jobs }}
 group_reporting=1
-{% if action_params.runtime %}
-runtime={{ action_params.runtime }}
-{% endif %}
+runtime=30
 {% for dev in action_params.disk_devices %}
 [job {{loop.index}}]
 filename={{dev}}

--- a/templates/rbd.fio
+++ b/templates/rbd.fio
@@ -8,9 +8,7 @@ rw={{ action_params.operation }}
 bs={{ action_params.block_size }}
 numjobs={{ action_params.num_jobs }}
 group_reporting=1
-{% if action_params.runtime %}
-runtime={{ action_params.runtime }}
-{% endif %}
+runtime=30
 [rbd_iodepth32]
 iodepth={{ action_params.iodepth }}
 {% endif %}


### PR DESCRIPTION
Add interface for relation based integration with Prometheus.

This fixes an outstanding issue with using a push gateway
from multiple ceph-benchmarking units which results in
data being overwritten prior to collection.

By running a Prometheus target during execution of the test
actions, data can be uniquely collated from all units.

Drop configuration option for push gateway as its effectively
useless.